### PR TITLE
feat: add custom value separator for jsonToCsv transform

### DIFF
--- a/src/main/java/org/wso2/carbon/module/csv/JsonToCsvTransformer.java
+++ b/src/main/java/org/wso2/carbon/module/csv/JsonToCsvTransformer.java
@@ -25,15 +25,18 @@ import com.google.gson.JsonObject;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.module.core.SimpleMediator;
 import org.wso2.carbon.module.core.SimpleMessageContext;
+import org.wso2.carbon.module.csv.constant.Constants;
 import org.wso2.carbon.module.csv.constant.ParameterKey;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Optional;
 
 import static org.wso2.carbon.module.csv.constant.Constants.DEFAULT_EXPRESSION_SPLITTER;
 import static org.wso2.carbon.module.csv.util.PropertyReader.getBooleanParam;
+import static org.wso2.carbon.module.csv.util.PropertyReader.getCharParam;
 
 /**
  * Transformer to transform JSON content to a CSV content.
@@ -43,6 +46,7 @@ public class JsonToCsvTransformer extends SimpleMediator {
     @Override
     public void mediate(SimpleMessageContext mc) {
         final boolean suppressEscapeCharacters = getBooleanParam(mc, ParameterKey.SUPPRESS_ESCAPE_CHARACTERS);
+        final Optional<Character> customValueSeparator = getCharParam(mc, ParameterKey.CUSTOM_VALUE_SEPARATOR);
 
         String[] header = getHeader(mc);
         mc.getJsonArrayStream()
@@ -60,7 +64,7 @@ public class JsonToCsvTransformer extends SimpleMediator {
 
                     return csvEntry.toArray(new String[]{});
                 })
-                .collect(mc.collectToCsv(header, suppressEscapeCharacters));
+                .collect(mc.collectToCsv(header, customValueSeparator.orElse(Constants.DEFAULT_CSV_SEPARATOR), suppressEscapeCharacters));
     }
 
     /**

--- a/src/main/resources/jsonToCsv/json_to_csv_template.xml
+++ b/src/main/resources/jsonToCsv/json_to_csv_template.xml
@@ -18,8 +18,10 @@
 <template xmlns="http://ws.apache.org/ns/synapse" name="jsonToCsv">
     <parameter name="customHeader" description="Comma separated string of header for Csv payload"/>
     <parameter name="suppressEscaping" description="Whether to suppress Escape Characters in the output Csv payload"/>
+    <parameter name="customValueSeparator" description="Specify a value separator for CSV output. Default is comma ( , )"/>
     <sequence>
         <property name="customHeader" expression="$func:customHeader"/>
+        <property name="customValueSeparator" expression="$func:customValueSeparator"/>
         <property name="suppressEscaping" expression="$func:suppressEscaping"/>
         <class name="org.wso2.carbon.module.csv.JsonToCsvTransformer"/>
     </sequence>

--- a/src/main/resources/uischema/jsonToCsv.json
+++ b/src/main/resources/uischema/jsonToCsv.json
@@ -39,6 +39,17 @@
                 {
                   "type": "attribute",
                   "value": {
+                    "name": "customValueSeparator",
+                    "displayName": "Separator",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Specify a value separator for CSV output. Default is comma ( , )"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
                     "name": "suppressEscaping",
                     "displayName": "Suppress Escaping",
                     "inputType": "booleanOrExpression",


### PR DESCRIPTION
This PR will fix issue [1]

This PR introduces the `customValueSeparator` parameter to `JsonToCsv` transformation, so that custom separator (Eg: "|") can be used in the output CSV.

[1]https://github.com/wso2/product-micro-integrator/issues/4068

